### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Airtable Python.
 .. code:: python
 
     import airtable
-    at = airtable.Airtable('BASE_ID', 'API_KEY')
+    at = airtable.Airtable('BASE_ID', 'ACCESS_TOKEN')
     at.get('TABLE_NAME')
 
 Here's an example of response from the Restaurant's example base


### PR DESCRIPTION
api keys are deprecated and will no longer be supported next year but using an access key as generated at https://airtable.com/developers/web/guides/personal-access-tokens in the airtable.Airtable method works just the same as the API_KEY currently does. lets shift the language to what it will be in the future.