### PR TITLE
Update error handling to branch on shape of error

### DIFF
--- a/airtable/__init__.py
+++ b/airtable/__init__.py
@@ -102,10 +102,21 @@ class Airtable(object):
             headers=self.headers)
         if response.status_code == requests.codes.ok:
             return response.json(object_pairs_hook=self._dict_class)
-        error_json = response.json().get('error', {})
-        raise AirtableError(
-            error_type=error_json.get('type', str(response.status_code)),
-            message=error_json.get('message', json.dumps(response.json())))
+        error_json = r.json().get('error', {})
+            if isinstance(error_json, dict):
+                error_type = error_json.get('type', str(r.status_code))
+                message = error_json.get('message', json.dumps(r.json()))
+            elif isinstance(error_json, str):
+                error_type = str(r.status_code)
+                message = error_json
+            else:
+                error_type = str(r.status_code)
+                message = json.dumps(r.json())
+
+            raise AirtableError(
+                error_type=error_type,
+                message=message
+            )
 
     def get(  # pylint: disable=invalid-name
             self, table_name, record_id=None, limit=0, offset=None,


### PR DESCRIPTION
Per the documentation, the response to an API error will _typically_ be a dictionary , but may _sometimes_ be a string, as described here: https://airtable.com/developers/web/api/errors#anchor-404

Since this string-only response is not supported in airtable.py currently, this case will raise a somewhat opaque error. An example of the type of issue you will see was reported in issue #60.

This PR adds some branches in the logic to handle both expected cases, as well as a generalized and also a fallback.